### PR TITLE
Port pipeline fixes from downstream forks

### DIFF
--- a/.github/actions/github_action_main.py
+++ b/.github/actions/github_action_main.py
@@ -21,9 +21,6 @@ import sys
 
 
 def main():
-#    logging.debug(f"environment variables are {os.environ}")
-#    print(f"environment variables are {os.environ}")
-
     command = os.environ["INPUT_ACTION"]
     print("github_action_main: INPUT_ACTION: ", command)
     path = os.environ["INPUT_PATH"]
@@ -31,23 +28,22 @@ def main():
     input = os.environ["INPUT_INPUTTTL"]
     print(f"inputttl string: {input}")
     inputttl = input.split('|')
-    # inputttl is a list of skos rdf vocabulary filenames with Turtle serialization
-    # vocab_source_dir is the path to the directory that contains the source files
     for filename in inputttl:
-            print(f"files to load: {filename}")
+        print(f"files to load: {filename}")
 
     input = os.environ["INPUT_INPUTVOCABURI"]
     print(f"inputvocaburi string: {input}")
     inputvocaburi = input.split('|')
     for auri in inputvocaburi:
-            print(f"vocab URIs: {auri}")
+        print(f"vocab URIs: {auri}")
 
-    
-    # make sure have cache directory -- this is where the sqlAlchemy db will be         
+    if len(inputttl) != len(inputvocaburi):
+        print(f"inputttl ({len(inputttl)}) and inputvocaburi ({len(inputvocaburi)}) counts do not match. Exiting.")
+        sys.exit(-1)
+
     cachepath = "cache/vocabularies.db"
-    # this is the directory that holds the source SKOS ttl files.
-    sourcevocabdir = "vocabulary"
-
+    sourcevocabdir = os.environ.get("INPUT_VOCABDIR") or "vocabulary"
+    print(f"github_action_main: source vocab directory: {sourcevocabdir}")
 
     print("github_action_main: target path for output: ", path)
     if path is None:
@@ -55,70 +51,74 @@ def main():
         sys.exit(-1)
     if not os.path.exists(path):
         os.makedirs(path)
-        # Change to 777 so subsequent steps that deal with the directory don't run into permissions issues
         os.chmod(path, 777)
         print(f"Created {path} since it didn't exist.")
 
-    # do function of original Makefile here
-  
-    for inputf in inputttl:
-        theindex=0
-        result=load_cachedb(sourcevocabdir + "/" + inputf + ".ttl", cachepath, inputvocaburi[theindex] )
-        if (result == 0):
-           print(f"load_cachedb call successful for: {inputf}, {inputvocaburi[theindex]}")
-        else:
-           print(f"load_cachedb had problem processing: {inputf},{inputvocaburi[theindex]}")
-        theindex = theindex + 1
+    # Process each vocabulary independently with a fresh cache DB so data from
+    # previously-loaded vocabularies cannot pollute queries for the current one.
+    for index, inputf in enumerate(inputttl):
+        voc_uri = inputvocaburi[index]
+        print(f"\n=== Processing {inputf} ({voc_uri}) ===")
 
+        _reset_cache_db(cachepath)
 
-    if command == "uijson":
-        print("Generating uijson for inclusion in webUI build")
-        index = 0
-        while index < len(inputttl):
-            _run_uijson_in_container(os.path.join(path, inputttl[index]+".json"), inputvocaburi[index])
-            index += 1
-    elif command == "docs":
-        print("Generating markdown and html docs")
-        index = 0
-        print(f"input markdown file: {inputttl[index]}, vocab uri: {inputvocaburi[index]}")
-        while index < len(inputttl):
-            result = _run_docs_in_container(os.path.join(path, inputttl[index]+".md"), inputvocaburi[index])
+        ttl_path = os.path.join(sourcevocabdir, inputf + ".ttl")
+        if load_cachedb(ttl_path, cachepath, voc_uri) != 0:
+            print(f"load_cachedb had problem processing: {inputf}, {voc_uri}; skipping")
+            continue
+        print(f"load_cachedb call successful for: {inputf}, {voc_uri}")
+
+        if command == "uijson":
+            print("Generating uijson for inclusion in webUI build")
+            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri, cachepath)
+        elif command == "docs":
+            print("Generating markdown and html docs")
+            md_path = os.path.join(path, inputf + ".md")
+            result = _run_docs_in_container(md_path, voc_uri, cachepath)
             if result == 0:
-                _quarto_render_html((os.path.join(path, inputttl[index]+".md")),path)
+                _quarto_render_html(md_path, path)
             else:
-                print(f"problem with {inputttl[index]}, don't call quarto")
-            index += 1
-    else:
-        print(f"Unknown command {command}.  Exiting.")
-        sys.exit(-1)
+                print(f"problem with {inputf}, don't call quarto")
+        else:
+            print(f"Unknown command {command}.  Exiting.")
+            sys.exit(-1)
+
+
+def _reset_cache_db(cachepath: str):
+    """Delete any prior cache DB file so each vocab starts from a clean store.
+
+    navocab's internal purge path is unreliable (see known issues), so we
+    remove the file here before re-creating it via vocab.py load.
+    """
+    cachedir = os.path.dirname(cachepath)
+    if cachedir and not os.path.exists(cachedir):
+        os.makedirs(cachedir)
+    if os.path.exists(cachepath):
+        try:
+            os.remove(cachepath)
+            print(f"Removed stale cache DB: {cachepath}")
+        except OSError as e:
+            print(f"Could not remove {cachepath}: {e}")
+
 
 def load_cachedb(inputf, cachepath, voc_uri):
-    # tools/vocab.py --verbosity ERROR -s $(CACHE) load $(SRC)/$@
-
     print(f"cachdb file to load: {inputf}")
-    load_args = ["--verbosity","DEBUG", "-s", cachepath, "load", inputf, voc_uri]
+    load_args = ["--verbosity", "DEBUG", "-s", cachepath, "load", inputf, voc_uri]
     result = _run_python_in_container("/app/tools/vocab.py", load_args, f="")
-    if (result == 0):
+    if result == 0:
         print(f"vocab.py.load call successful for {inputf}")
         return 0
-    else:
-        print(f"vocab.py.load had problem processing {inputf}")
-        return 1
-    
+    print(f"vocab.py.load had problem processing {inputf}")
+    return 1
 
-def _quarto_render_html(markdown_in:str, output_path:str):
-#     print("In githubActionMain: Quarto render: ",markdown_in,  output_path)
-#     result = subprocess.run(["/opt/quarto/bin/quarto", "check"])
-#     print("Quarto check result ", result.returncode)
-#  NOTE update quarto location for your local install...
-     result = subprocess.run(["/opt/quarto/bin/quarto", "render", markdown_in, "-t", "html"])
-#     print("Quarto call result ", result.returncode)
-     if (result.returncode == 0):
-         print(f"Quarto call successful for {markdown_in}")
-         return 0
-     else:
-         print(f"Quarto had problem processing {markdown_in}")
-         return 1
+
+def _quarto_render_html(markdown_in: str, output_path: str):
+    result = subprocess.run(["/opt/quarto/bin/quarto", "render", markdown_in, "-t", "html"])
+    if result.returncode == 0:
+        print(f"Quarto call successful for {markdown_in}")
+        return 0
+    print(f"Quarto had problem processing {markdown_in}")
+    return 1
 
 
 def _run_make_in_container(target: str):
@@ -126,39 +126,36 @@ def _run_make_in_container(target: str):
     subprocess.run(["/usr/bin/make", "-C", "/app", "-f", "/app/Makefile", target])
 
 
-def _run_uijson_in_container(output_path: str, vocab_location: str):
+def _run_uijson_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        vocab_args = ["-s", "/app/cache/vocabularies.db", "uijson", vocab_location, "-e"]
+        vocab_args = ["-s", cachepath, "uijson", vocab_location, "-e"]
         testflag = _run_python_in_container("/app/tools/vocab.py", vocab_args, f)
-        if (testflag == 0):
+        if testflag == 0:
             print(f"Run_uijson: Successfully wrote uijson file to {output_path}")
             return 0
-        else:
-            print(f"problem processing {vocab_location}")
-            return 1
+        print(f"problem processing {vocab_location}")
+        return 1
 
-def _run_docs_in_container(output_path: str, vocab_location: str):
+
+def _run_docs_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        docs_args = ["/app/cache/vocabularies.db", vocab_location]
+        docs_args = [cachepath, vocab_location]
         testflag = _run_python_in_container("/app/tools/vocab2mdCacheV2.py", docs_args, f)
-        if (testflag == 0):
+        if testflag == 0:
             print(f"Docs in container: Successfully wrote doc file {vocab_location} to {output_path}")
             return 0
-        else:
-            print(f"vocab2mdCacheV2. problem processing {vocab_location}")
-            return 1
+        print(f"vocab2mdCacheV2. problem processing {vocab_location}")
+        return 1
+
 
 def _run_python_in_container(path_to_python_script: str, args: list[str], f):
     subprocess_args = [sys.executable, path_to_python_script]
     subprocess_args.extend(args)
-    if f=="":
+    if f == "":
         result = subprocess.run(subprocess_args)
     else:
         result = subprocess.run(subprocess_args, stdout=f)
-#    print("container call result ", result.returncode)
     return result.returncode
-
-
 
 
 if __name__ == "__main__":

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.12-slim
 WORKDIR /app
 COPY ./.github/actions/github_action_main.py .
 COPY ./tools ./tools
@@ -20,7 +20,7 @@ RUN pip install -r /app/tools/requirements.txt
 RUN curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb
 RUN gdebi --non-interactive quarto-linux-amd64.deb
 
-ENV PYTHONPATH /app
+ENV PYTHONPATH=/app
 ENTRYPOINT ["/app/github_action_main.py"]
 
 # This is for debugging the Docker image build process, ensures the container stays up

--- a/action.yml
+++ b/action.yml
@@ -3,25 +3,28 @@
 #  for information on how this works
 
 name: 'Vocabulary Action'
-author: 'Dave Vieglais( https://orcid.org/0000-0002-6513-4996), 
+author: 'Dave Vieglais (https://orcid.org/0000-0002-6513-4996),
          Stephen M Richard (https://orcid.org/0000-0001-6041-5302)'
-description: 'creates a docker container to run python routines that 
-       1) load skos (rdf/turtle) vocabularies into an sqlAlchmey
-       2) generate markdown from the skos vocabularies using Quarto markdown'
+description: 'creates a docker container to run python routines that
+       1) load skos (rdf/turtle) vocabularies into an sqlAlchemy store
+       2) generate markdown (Quarto-flavor) and HTML from the skos vocabularies'
 inputs:
-  action:  
-    description: 'Which action to run -- defaults to docs, which generated markdown and html representations of the vocabulary'
+  action:
+    description: 'Which action to run -- defaults to docs, which generates markdown and html representations of the vocabulary'
     required: true
     default: 'docs'
-  path: 
+  path:
     description: 'Path to the output directory for script output'
     required: true
+  vocabdir:
+    description: 'Repository-relative directory containing the source ttl files for this workflow. Defaults to "vocabulary" to match the conventional single-vocab layout; set to a different directory name to point the action at a per-topic subfolder (e.g. "geochemistry", "ETmaterials"). One workflow file per target directory is the recommended pattern.'
+    required: false
+    default: 'vocabulary'
   inputttl:
-    description: 'list of skos rdf/turtle files **without** the .ttl extension'
+    description: 'Pipe-delimited list of skos rdf/turtle file names (without .ttl extension) located in <vocabdir>'
     required: true
   inputvocaburi:
-    description: 'list of ConceptScheme URIs for the skos vocabularies in this repo. 
-                   The URIs will be matched with the SKOS files based on order'
+    description: 'Pipe-delimited list of ConceptScheme URIs, one per inputttl entry in the same order. URIs must be CURIEs resolvable from @prefix declarations in their ttl file.'
     required: true
 
 runs:   # see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions
@@ -37,3 +40,4 @@ runs:   # see https://docs.github.com/en/actions/creating-actions/metadata-synta
     - ${{ inputs.path }}
     - ${{ inputs.inputttl }}
     - ${{ inputs.inputvocaburi }}
+    - ${{ inputs.vocabdir }}

--- a/tools/navocab/__init__.py
+++ b/tools/navocab/__init__.py
@@ -10,7 +10,6 @@ import rdflib
 import rdflib.namespace
 import rdflib.plugins.sparql
 import sqlalchemy
-import logging
 import logging.config
 
 STORE_IDENTIFIER = "https://w3id.org/isample/vocabulary"
@@ -88,10 +87,17 @@ PREFIX rdfs: <{NS['rdfs']}>
         return len(self._g)
 
     def purge_store(self):
-        """Clears out the Sqlite cache."""
-        # added by SMR to enable purge
-        L.debug("purge_store: purging %s", self.store_identifier)
-        graph.destroy(self.storage_uri)
+        """No-op: delete the Sqlite cache file externally instead.
+
+        The previous implementation referenced an undefined ``graph`` local
+        and crashed on invocation. In-place destruction via rdflib-sqlalchemy
+        has been unreliable, so the driver (see github_action_main.py) removes
+        the DB file between vocabularies rather than relying on this method.
+        """
+        L.warning(
+            "purge_store is disabled; delete the sqlite file at %s externally",
+            self.storage_uri,
+        )
 
     def _initialize_store(self, purge=False):
         """Sets up the rdf store using an Sqlite cache."""

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@ rdflib
 SQLAlchemy
 rdflib-sqlalchemy
 requests
+setuptools<81

--- a/tools/vocab2mdCacheV2.py
+++ b/tools/vocab2mdCacheV2.py
@@ -73,9 +73,6 @@ LOG_LEVELS = {
     "CRITICAL": logging.CRITICAL,
 }
 
-def getLogger():
-    return logging.getLogger("voc2md")
-
 
 
 NS = {
@@ -95,7 +92,11 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 """
 
 INDENT = "  "
+verbosity = "INFO"
+#control print errors; these will appear in the output markdown file.
 
+def getLogger():
+    return logging.getLogger("vocab2mdCacheV2")
 
 def skosT(term):
     return rdflib.URIRef(f"{NS['skos']}{term}")
@@ -126,26 +127,65 @@ def listVocabularies(g):
     return res
 
 def getVocabRoot(g, v):
-    """Get top concept of the specific vocabulary
+    """Get top concepts of the specific vocabulary.
+
+    Accepts both concept->scheme (``skos:topConceptOf``) and
+    scheme->concept (``skos:hasTopConcept``) assertions, since SKOS
+    vocabularies in the wild use either (or both).
+
+    If neither assertion appears, falls back to every concept in the
+    scheme treated as a flat root. The fallback honors both direct
+    ``rdf:type skos:Concept`` and subclass typings (``rdf:type ?C`` where
+    ``?C rdfs:subClassOf skos:Concept``) — the latter is needed for
+    vocabularies like MMISW whose items are typed with a bespoke class
+    that declares ``rdfs:subClassOf skos:Concept``.
     """
-    q = PFX + """SELECT ?s   WHERE { ?s skos:topConceptOf ?vocabulary . }"""
+    q = PFX + """SELECT DISTINCT ?s WHERE {
+        { ?s skos:topConceptOf ?vocabulary . }
+        UNION
+        { ?vocabulary skos:hasTopConcept ?s . }
+    }"""
     qres = g.query(q, initBindings={'vocabulary': v})
-    res = []
-    for row in qres:
-        res.append(row[0])
-    return res
+    res = [row[0] for row in qres]
+    if res:
+        return res
+
+    q = PFX + """SELECT DISTINCT ?s WHERE {
+        ?s skos:inScheme ?vocabulary .
+        {
+            ?s rdf:type skos:Concept .
+        } UNION {
+            ?s rdf:type ?cls .
+            ?cls rdfs:subClassOf skos:Concept .
+        }
+    }"""
+    qres = g.query(q, initBindings={'vocabulary': v})
+    return [row[0] for row in qres]
 
 def getNarrower(g, v, r):
-    q = rdflib.plugins.sparql.prepareQuery(PFX + """SELECT ?s
+    """Return concepts that are skos:broader of r.
+
+    Prefers results scoped by ``skos:inScheme`` but falls back to an
+    unscoped lookup when concepts in the source file omit inScheme
+    assertions (common when the vocabulary relies on topConcept/broader
+    linkage alone).
+    """
+    scoped = rdflib.plugins.sparql.prepareQuery(PFX + """SELECT ?s
     WHERE {
         ?s skos:inScheme ?vocabulary .
         ?s skos:broader ?parent .
     }""")
-    qres = g.query(q, initBindings={'vocabulary': v, 'parent': r})
-    res = []
-    for row in qres:
-        res.append(row[0])
-    return res
+    qres = g.query(scoped, initBindings={'vocabulary': v, 'parent': r})
+    res = [row[0] for row in qres]
+    if res:
+        return res
+
+    unscoped = rdflib.plugins.sparql.prepareQuery(PFX + """SELECT ?s
+    WHERE {
+        ?s skos:broader ?parent .
+    }""")
+    qres = g.query(unscoped, initBindings={'parent': r})
+    return [row[0] for row in qres]
 
 def getObjects(g, s, p):
     L = getLogger()
@@ -218,16 +258,16 @@ def describeTerm(g, t, depth=0, level=1):
         res.append(f"{hl} {labels[0].strip()}")
         for label in labels[1:]:
             res.append(f"* `{label}`")
-        res.append("")
+#        res.append("")
 
     broader = getObjects(g, t, skosT('broader'))
     if len(broader) > 0:
-        res.append("")
+#        res.append("")
         res.append(f"- Child of:")
         for b in broader:
             bt = b.split('/')[-1]
             res.append(f" [`{bt}`](#{bt})")
-    res.append("")
+#    res.append("")
     # The textual description will be present in rdfs:comment or
     # skos:definition. 
     comments = []
@@ -243,10 +283,10 @@ def describeTerm(g, t, depth=0, level=1):
         res += lines
     seealsos = getObjects(g, t, rdfsT('seeAlso'))
     if len(seealsos) > 0:
-        res.append("")
+#       res.append("")
         res.append(f"- See Also:")
         for seealso in seealsos:
-            res.append(f"* [{seealso.n3(g.namespace_manager)}]({seealso})")
+            res.append(f"  * [{seealso.n3(g.namespace_manager)}]({seealso})")
     altlabels = []
     for altlabel in getObjects(g, t, skosT('altLabel')):
         altlabels.append(altlabel)
@@ -254,11 +294,11 @@ def describeTerm(g, t, depth=0, level=1):
         delimiter = ""
         if len(altlabels) > 1:
             delimiter = ", "
-        res.append("")
+#        res.append("")
         res.append(f"- **Alternate labels:**")
         for altlabel in altlabels:
             res.append(f"{altlabel}{delimiter}")
-        res.append("")
+ #       res.append("")
 
     sources = []
     for source in getObjects(g, t, dctT('source')):
@@ -267,13 +307,13 @@ def describeTerm(g, t, depth=0, level=1):
         delimiter = ""
         if len(sources) > 1:
             delimiter = ", "
-        res.append("")
+#        res.append("")
         res.append(f"- **Source:**")
         for source in sources:
             res.append(f"{source}{delimiter}")
-        res.append("")
+ #       res.append("")
 
-    res.append(f"- Concept URI token: {t.split('/')[-1]}")
+    res.append(f"- Concept URI: {t}")
     res.append("")
 
     return res
@@ -398,7 +438,9 @@ def main(source, vocabulary):
     # res = []
     # res.append(conceptschemelist(vgraph))
 
-    verbosity = "DEBUG".upper()
+    # logging verbosity is set with global varable , at top
+    # when run github action, log statements are in the github action log.
+    # verbosity = "DEBUG".upper()
     logging_config["loggers"][""]["level"] = verbosity
     logging.config.dictConfig(logging_config)
     L = getLogger()


### PR DESCRIPTION
Ports nine fixes (seven bug fixes + two enhancements) from the downstream forks — \`isamplesorg/metadata_profile_earth_science\`/\`_archaeology\`/\`_biology\` and \`amds-ldeo/Vocabulary\` — back to this template. All changes are backward-compatible; existing single-vocabulary forks will work unchanged.

## Fixes

### Dockerfile
1. **Pin `FROM python:3.12-slim`** (was `python:3-slim`). The `3-slim` tag started resolving to 3.14 in 2025-10, and 3.14 removed \`pkg_resources\` which \`rdflib-sqlalchemy\` imports at module load — forks started hitting silent build failures.
2. **\`ENV PYTHONPATH=/app\`** (key=value form). Silences the builder's \`LegacyKeyValueFormat\` warning.

### tools/requirements.txt
3. **Add \`setuptools<81\`**. \`rdflib-sqlalchemy\` still imports \`pkg_resources\` from \`setuptools\`; setuptools 81 removed it.

### tools/vocab2mdCacheV2.py
4. **\`getVocabRoot\` UNIONs \`skos:topConceptOf\` and \`skos:hasTopConcept\`.** Real SKOS vocabularies use either direction (or both).
5. **New fallback: flat-scheme + subclass typing.** When neither top assertion is present, the fallback lists every \`?s skos:inScheme ?vocabulary\` as a flat root. The fallback UNIONs direct \`rdf:type skos:Concept\` with subclass typings (\`rdf:type ?C . ?C rdfs:subClassOf skos:Concept .\`), so vocabularies like MMISW whose items use a bespoke subclass of \`skos:Concept\` render without source edits.
6. **\`getNarrower\` falls back to an unscoped \`skos:broader\` query** when concepts lack \`skos:inScheme\`, so topConcept-only hierarchies traverse correctly.

### tools/navocab/__init__.py
7. **\`purge_store\` no longer crashes on an undefined \`graph\` local.** Logs a warning and defers to external file deletion (see \`_reset_cache_db\` in the driver).

### .github/actions/github_action_main.py
8. **Per-vocab cache DB reset with \`_reset_cache_db\` and an \`enumerate\` loop.** The prior \`theindex=0\` inside the loop always processed \`inputvocaburi[0]\`, misbinding CURIEs to the wrong ttl after the first iteration.
9. **Cache path consistency.** \`_run_docs_in_container\` and \`_run_uijson_in_container\` now take \`cachepath\` and use it rather than hardcoding \`"/app/cache/vocabularies.db"\`. GitHub Actions docker-action invocation runs with \`--workdir /github/workspace\`, so the load step wrote to \`/github/workspace/cache/vocabularies.db\` while the docs/uijson step read from \`/app/cache/vocabularies.db\`. This is hidden in forks that commit \`cache/\` back to \`main\` after each run (build-time \`COPY\` puts a stale DB at \`/app/cache/\`, one run behind); it fails outright in forks that gitignore \`cache/\`.

### action.yml
10. **New optional \`vocabdir\` input** (default \`"vocabulary"\`). Lets a single action serve per-topic subdirectory layouts (one workflow file per directory). Existing workflows need no changes to take advantage of the default.

## Test plan

- Existing forks that already carry fixes 1–7 (the three \`metadata_profile_*\` repos) need no behavioral change; items 8, 9, 10 are net-new.
- \`GeoSamples/vocabularies\` and other still-unfixed forks can rebase/merge once this lands.
- \`amds-ldeo/Vocabulary\` (which exercised all 10 items against 11 vocabularies across four subdirectories) verifies each end-to-end with the Docker build, the dispatch flow, and the local Option-A pipeline.

## Co-authorship

\`Co-Authored-By: Claude Opus 4.7 (1M context)\` per my workflow — debugging and pair-programming assistance.